### PR TITLE
use hashlocation to prevent 404s

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -21,7 +21,7 @@ module.exports = function(environment) {
     modulePrefix: 'druid-ui',
     environment: environment,
     baseURL: '/',
-    locationType: 'auto',
+    locationType: 'hash',
     contentSecurityPolicy: {
       'style-src': '* unsafe-inline'
     },


### PR DESCRIPTION
Since we have datasource route now. Refreshing the page with /datasource in the URL causes https://github.com/yahoo/druid-extensions/tree/master/static_ui to not find any resource with this name and thus returning 404